### PR TITLE
feat: customizable logo & multi workspace

### DIFF
--- a/api/configs/feature/__init__.py
+++ b/api/configs/feature/__init__.py
@@ -853,7 +853,7 @@ class LoginConfig(BaseSettings):
     )
     ALLOW_CREATE_WORKSPACE: bool = Field(
         description="whether to enable create workspace",
-        default=False,
+        default=True,
     )
 
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -24,6 +24,11 @@ NEXT_TELEMETRY_DISABLED=1
 # Disable Upload Image as WebApp icon default is false
 NEXT_PUBLIC_UPLOAD_IMAGE_AS_ICON=false
 
+# Logo used across the Console and Webapp
+NEXT_PUBLIC_BRAND_LOGO=/logo/logo.svg
+# Logo used on dark backgrounds
+NEXT_PUBLIC_BRAND_LOGO_WHITE=/logo/logo-monochrome-white.svg
+
 # The timeout for the text generation in millisecond
 NEXT_PUBLIC_TEXT_GENERATION_TIMEOUT_MS=60000
 

--- a/web/app/components/base/logo/dify-logo.tsx
+++ b/web/app/components/base/logo/dify-logo.tsx
@@ -5,9 +5,12 @@ import useTheme from '@/hooks/use-theme'
 import { basePath } from '@/utils/var'
 export type LogoStyle = 'default' | 'monochromeWhite'
 
+const defaultLogo = process.env.NEXT_PUBLIC_BRAND_LOGO || '/logo/logo.svg'
+const defaultMonochromeLogo = process.env.NEXT_PUBLIC_BRAND_LOGO_WHITE || '/logo/logo-monochrome-white.svg'
+
 export const logoPathMap: Record<LogoStyle, string> = {
-  default: '/logo/logo.svg',
-  monochromeWhite: '/logo/logo-monochrome-white.svg',
+  default: defaultLogo,
+  monochromeWhite: defaultMonochromeLogo,
 }
 
 export type LogoSize = 'large' | 'medium' | 'small'


### PR DESCRIPTION
## Summary
- make workspace creation enabled by default
- expose logo path through env vars for web

## Testing
- `bash dev/pytest/pytest_unit_tests.sh` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_68378684a71083308b6e044543f76fb7